### PR TITLE
(fix): ensureFileSync and drop cjs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
   "author": "Jaya Krishna Namburu <namburu1995@gmail.com>",
   "type": "module",
   "main": "dist/loader.js",
-  "module": "dist/loader.js",
   "types": "dist/loader.d.ts",
   "exports": {
-    ".": "dist/loader.cjs"
+    ".": "dist/loader.js"
   },
   "scripts": {
-    "build": "tsup src/loader.ts --format esm,cjs --dts",
+    "build": "tsup src/loader.ts --format esm --dts",
     "clean": "rimraf dist",
     "commit": "git-cz",
     "commit-msg": "commitlint --edit $1",

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,5 @@
-import { accessSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ImportMap } from "@jspm/import-map";
 import fetch from "node-fetch";
@@ -9,15 +9,40 @@ import { ConstructCachePath, Context, NextResolve, UrlType } from './types'
 const cacheMap = new Map();
 
 /**
+ * nsureDirSync
+ * @description a function to ensure the dis exists
+ * @param dirPath
+*/
+
+function ensureDirSync(dirPath: string) {
+  if (existsSync(dirPath)) {
+    return;
+  }
+
+  const parentDir = dirname(dirPath);
+  if (parentDir !== dirPath) {
+    ensureDirSync(parentDir);
+  }
+
+  mkdirSync(dirPath);
+}
+
+/**
  * ensureFileSync
  * @description a convenience function to ensure a file exists
  * @param path
  */
 function ensureFileSync(path: string) {
+  const dirPath = dirname(path);
+
+  if (!existsSync(dirPath)) {
+    ensureDirSync(dirPath);
+  }
+
   try {
-    accessSync(path);
-  } catch (err) {
-    writeFileSync(path, '');
+    writeFileSync(path, '', { flag: 'wx' });
+  } catch {
+    console.log(`Failed in creating ${path}`)
   }
 }
 
@@ -166,13 +191,15 @@ export const parseModule = async (specifier: string, modulePath: string) => {
   const { protocol } = new URL(modulePath);
   const isNode = protocol === "node:";
   const isFile = protocol === "file:";
+
   if (isNode || isFile) return specifier;
 
   const cachePath = constructCachePath({ cache, modulePath })
+
   cacheMap.set(`file://${cachePath}`, modulePath);
   if (existsSync(cachePath)) return cachePath
-
   const code = await (await fetch(modulePath)).text();
+
   ensureFileSync(cachePath);
   writeFileSync(cachePath, code);
 

--- a/tests/e2e/test-prettier.js
+++ b/tests/e2e/test-prettier.js
@@ -1,0 +1,30 @@
+import standalone from 'prettier/standalone'
+import parserBabel from 'prettier/parser-babel'
+const { format } = standalone
+
+const CODE = String(`
+  function HelloWorld({greeting = "hello", greeted = '"World"', silent = false, onMouseOver,}) {
+
+    if(!greeting){return null};
+
+       // TODO: Don't use random in render
+    let num = Math.floor (Math.random() * 1E+7).toString().replace(/\.\d+/ig, "")
+
+    return <div className='HelloWorld' onMouseOver={onMouseOver}>
+
+      <strong>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</strong>
+      {greeting.endsWith(",") ? " " : <span style={{color: '\grey'}}>", "</span> }
+      <em>
+	{ greeted }
+	</em>
+      { (silent)
+        ? "."
+        : "!"}
+
+      </div>;
+
+  }
+`)
+
+const result = format(CODE, { parser: 'babel', plugins: [parserBabel] })
+console.log(result)


### PR DESCRIPTION
## Fixes

- Fixes #
- `ensueFileSync` is failing at nested paths.
- Drop the `cjs` build. Since we support only `esm` modules. And the `type: module` in package.json. We are marking the package as `esm`. So, no need to build two builds. And the `cjs` is not needed. As the basic version of node loaders has `esm` support.
