### PR TITLE
refactor: Add debug flag and skip missing deps from the importmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,15 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
+      "subject-case": [
+        2,
+        "never",
+        [
+          "upper-case",
+          "pascal-case",
+          "start-case"
+        ]
+      ],
       "header-max-length": [
         2,
         "always",

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,6 @@
 ![ci](https://github.com/jspm/node-importmap-http-loader/actions/workflows/ci.yml/badge.svg)
 [![Github](https://badgen.net/badge/icon/github?icon=github&label&color=black)](https://github.com/jspm/node-importmap-http-loader)
 
-
 #### Don't bother installing dependencies you don't need to! 🏇🏻💨
 
 With `@jspm/node-importmap-loader`, you can reference and execute dependencies directly to maximize productivity ⚡️,

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ImportMap } from "@jspm/import-map";
+import { argv } from "node:process";
+
 /**
  * ******************************************************
  * CONFIG 🗺️
@@ -18,3 +20,38 @@ export const nodeImportMapPath = join(root, "node.importmap");
 export const cache = join(root, ".cache");
 const map = existsSync(nodeImportMapPath) ? JSON.parse(readFileSync(nodeImportMapPath, { encoding: "utf8" })) : {};
 export const importmap = new ImportMap({ rootUrl: import.meta.url, map });
+
+interface OptionDefinition {
+  type?: string;
+  alias?: string;
+  default?: any;
+}
+
+interface Options {
+  args: string[];
+  options: Record<string, OptionDefinition>;
+}
+
+function parseArgs({ args, options: optionDefinitions }: Options) {
+  const parsedArgs: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i].replace(/^-+/, "");
+    const optionDefinition = optionDefinitions[arg];
+
+    if (optionDefinition) {
+      const value = args[i + 1];
+      parsedArgs[optionDefinition.alias || arg] = value !== undefined ? value : optionDefinition.default || true;
+      i++;
+    }
+  }
+
+  return { values: parsedArgs };
+}
+
+const { values } = parseArgs({
+  args: argv.slice(2),
+  options: { "debug-node-loader": { alias: "d", type: "boolean", default: false } },
+});
+
+export const isDebuggingEnabled = (): boolean => values["debug-node-loader"] as boolean;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -35,12 +35,20 @@ export const resolve = async (specifier: string, { parentURL }: Context, nextRes
   if (!parentURL || !nodeImportMapPath) return nextResolve(specifier);
   const cacheMapPath = cacheMap.get(parentURL) || parentURL;
   const modulePath = resolveModulePath(specifier, cacheMapPath);
+
+  if (modulePath === null) {
+    return nextResolve(specifier);
+  }
+
   const isNodeOrFileProtocol = checkIfNodeOrFileProtocol(modulePath);
   if (isNodeOrFileProtocol) return nextResolve(specifier);
+
   const nodeModuleCachePath = await resolveNodeModuleCachePath(modulePath);
   if (!nodeModuleCachePath) return nextResolve(specifier);
+
   cacheMap.set(`file://${nodeModuleCachePath}`, modulePath);
   const parsedNodeModuleCachePath = await resolveParsedModulePath(modulePath, nodeModuleCachePath);
   if (!parsedNodeModuleCachePath) return nextResolve(specifier);
+
   return nextResolve(parsedNodeModuleCachePath);
 };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -36,9 +36,7 @@ export const resolve = async (specifier: string, { parentURL }: Context, nextRes
   const cacheMapPath = cacheMap.get(parentURL) || parentURL;
   const modulePath = resolveModulePath(specifier, cacheMapPath);
 
-  if (modulePath === null) {
-    return nextResolve(specifier);
-  }
+  if (!modulePath) return nextResolve(specifier);
 
   const isNodeOrFileProtocol = checkIfNodeOrFileProtocol(modulePath);
   if (isNodeOrFileProtocol) return nextResolve(specifier);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { ensureFileSync } from "src/utils";
-import { IS_DEBUGGING } from "src/constants";
 import { logger } from "src/logger";
+import { isDebuggingEnabled } from "./config";
 
 /**
  * ******************************************************
@@ -12,7 +12,7 @@ import { logger } from "src/logger";
  * ******************************************************
  */
 
-const log = logger({ file: "parser", isLogging: IS_DEBUGGING });
+const log = logger({ file: "parser", isLogging: isDebuggingEnabled() });
 
 /**
  * parseNodeModuleCachePath

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,14 @@ export type LoggerOptions = {
   file: string;
   isLogging?: boolean;
 };
+
+export interface OptionDefinition {
+  type?: string;
+  alias?: string;
+  default?: any;
+}
+
+export interface Options {
+  args: string[];
+  options: Record<string, OptionDefinition>;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parseUrlPkg } from "@jspm/generator";
 import { parseNodeModuleCachePath } from "./parser";
-import { cache, importmap } from "./config";
-import { IS_DEBUGGING } from "./constants";
+import { cache, importmap, isDebuggingEnabled } from "./config";
 import { logger } from "./logger";
 
 /**
@@ -17,7 +16,7 @@ import { logger } from "./logger";
  * ******************************************************
  */
 
-const log = logger({ file: "loader", isLogging: IS_DEBUGGING });
+const log = logger({ file: "loader", isLogging: isDebuggingEnabled() });
 
 export const ensureDirSync = (dirPath: string) => {
   if (existsSync(dirPath)) return;
@@ -43,10 +42,21 @@ export const checkIfNodeOrFileProtocol = (modulePath: string) => {
   return isNode || isFile;
 };
 
-export const resolveModulePath = (specifier: string, cacheMapPath: string) => {
-  const modulePath = importmap.resolve(specifier, cacheMapPath);
-  log.debug("resolveModulePath:", { modulePath });
-  return modulePath;
+export const resolveModulePath = (specifier: string, cacheMapPath: string): string | null => {
+  try {
+    const modulePath = importmap.resolve(specifier, cacheMapPath);
+    log.debug("resolveModulePath:", { modulePath });
+    return modulePath;
+  } catch {
+    /*
+      If a module is not found in the importmap, we should just let the loader to skip it.
+      - Users might have installed it using `npm`.
+      - It can be a node-js dependency. (e.g. `assert`). We detect builtins using `node:` protocol.
+        But it is still not widely adopted yet.
+    */
+    log.debug(`Failed in resolving ${specifier} in ${cacheMapPath}`);
+    return null;
+  }
 };
 
 export const resolveNodeModuleCachePath = async (modulePath: string) => {

--- a/tests/e2e/test.js
+++ b/tests/e2e/test.js
@@ -4,7 +4,16 @@ import * as TeleportTypes from "@teleporthq/teleport-types";
 import * as react from "react";
 import * as reactRouter from "react-router";
 import * as reactRouterDom from "react-router-dom";
+import assert from "assert";
 
 // Write main module code here, or as a separate file with a "src" attribute on the module script.
-console.log(TeleportProjectGeneratorPreact, TeleportProjectGeneratorReact, TeleportTypes, react, reactRouter, reactRouterDom);
+console.log(
+  TeleportProjectGeneratorPreact,
+  TeleportProjectGeneratorReact,
+  TeleportTypes,
+  react,
+  reactRouter,
+  reactRouterDom,
+);
 console.log("Hello.......");
+console.log(assert);


### PR DESCRIPTION
This PR allows to skip any missing dependencies from the importmap.

And adds a debug flag which disables the logs by default. Much needed since it’s flossing the CI with lot of logs if enabled by default 😅
