### PR TITLE
fix: Package exports for the main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/loader.js",
   "types": "dist/loader.d.ts",
   "exports": {
-    ".": "dist/loader.js"
+    ".": "./dist/loader.js"
   },
   "bin": {
     "load-node-importmap": "node --loader dist/loader.js"


### PR DESCRIPTION
## Error

```sh
node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "dist/loader.js" defined in the package config /home/runner/work/api/api/node_modules/@jspm/node-importmap-loader/package.json imported from /home/runner/work/api/api/; targets must start with "./"
    at new NodeError (node:internal/errors:405:5)
    at invalidPackageTarget (node:internal/modules/esm/resolve:404:[10](https://github.com/jspm/api/actions/runs/7503600112/job/20428695764?pr=13#step:7:11))
    at resolvePackageTargetString (node:internal/modules/esm/resolve:457:[11](https://github.com/jspm/api/actions/runs/7503600112/job/20428695764?pr=13#step:7:12))
    at resolvePackageTarget (node:internal/modules/esm/resolve:536:[12](https://github.com/jspm/api/actions/runs/7503600112/job/20428695764?pr=13#step:7:13))
    at packageExportsResolve (node:internal/modules/esm/resolve:650:27)
```

## Fixes

The `package.json` exports should always prefix with `./` when exposing the entry points. Or else node will throw a error when used as 

```sh
node --loader @jspm/node-importmap-loader test/test.js
```